### PR TITLE
gscramble: Fix g_iVoters not being reset before we count players.

### DIFF
--- a/gscramble/addons/sourcemod/scripting/gscramble.sp
+++ b/gscramble/addons/sourcemod/scripting/gscramble.sp
@@ -52,7 +52,7 @@ comment these 2 lines if you want to compile without them.
 #endif
 #define REQUIRE_PLUGIN
 
-#define VERSION "3.0.33"
+#define VERSION "3.0.34"
 #define TEAM_RED 2
 #define TEAM_BLUE 3
 #define SCRAMBLE_SOUND  "vo/announcer_am_teamscramble03.mp3"
@@ -772,6 +772,7 @@ public Action:Timer_load(Handle:timer)
 {
 	g_RoundState = normal;
 	CreateTimer(1.0, Timer_GetTime);
+	g_iVoters = 0;
 	for (new i = 1; i <= MaxClients; i++)
 	{
 		if (IsClientInGame(i) && !IsFakeClient(i))
@@ -784,6 +785,7 @@ public Action:Timer_load(Handle:timer)
 
 updateVoters()
 {
+	g_iVoters = 0;
 	for (new i = 1; i <= MaxClients; i++)
 	{
 		if (IsClientInGame(i) && !IsFakeClient(i))


### PR DESCRIPTION
g_iVoters wasn't being reset to 0 before we counted the players in two different locations.

Also increment the version number to 3.0.34.
